### PR TITLE
FE-022-Shimron Fix: Mobile layout issues with About Us and Chat Assistant

### DIFF
--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -18,9 +18,15 @@
         android:theme="@style/Theme.SmishingDetectionApp"
         app:menu="@menu/activity_main_drawer" />
 
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@id/bottom_navigation">
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content"
+        android:paddingBottom="100dp">
 
         <ImageView
             android:id="@+id/HardhatLogo"
@@ -133,15 +139,13 @@
             android:layout_width="175dp"
             android:layout_height="100dp"
             android:layout_marginTop="16dp"
-            android:layout_marginEnd="18dp"
+            android:layout_marginStart="16dp"
             android:background="@drawable/buttons_rounded"
             android:gravity="bottom|start"
             android:text="About Us"
             android:textSize="20sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="1.0"
-            app:layout_constraintStart_toEndOf="@+id/helpBtn"
-            app:layout_constraintTop_toBottomOf="@+id/reportBtn" />
+            app:layout_constraintTop_toBottomOf="@+id/forumBtn"
+            app:layout_constraintStart_toStartOf="parent"/>
 
 
         <Button
@@ -197,13 +201,14 @@
             android:layout_width="175dp"
             android:layout_height="100dp"
             android:layout_marginTop="16dp"
-            android:layout_marginEnd="140dp"
+            android:layout_marginStart="16dp"
             android:background="@drawable/buttons_rounded"
             android:gravity="bottom|start"
             android:text="@string/chat_assistant_btn"
             android:textSize="20sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/reportBtn" />
+            app:layout_constraintTop_toBottomOf="@+id/aboutUsBtn"
+            app:layout_constraintStart_toStartOf="parent" />
+
 
         <ImageView
             android:id="@+id/imageView7"
@@ -262,9 +267,10 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
             android:layout_marginEnd="4dp"
-            app:layout_constraintEnd_toEndOf="@+id/aboutMeBtn"
-            app:layout_constraintTop_toTopOf="@+id/aboutMeBtn"
+            app:layout_constraintEnd_toEndOf="@+id/aboutUsBtn"
+            app:layout_constraintTop_toTopOf="@+id/aboutUsBtn"
             app:srcCompat="@drawable/outline_arrow_outward_24" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
 </RelativeLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.2"
+agp = "8.9.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Nov 14 12:44:40 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Enabled ScrollView for vertical scrolling on mobile
- Repositioned About Us below forumBtn
- Moved Chat Assistant to its own row to prevent overlap
- Fixed incorrect icon reference for About Us button

![Screenshot 2025-04-05 115640](https://github.com/user-attachments/assets/6feef398-d87d-430d-87d7-79e9d0018e88)

