### PR TITLE
Fixing Fe-018--news section visual enhancement

### DIFF
--- a/app/src/main/res/layout/activity_news.xml
+++ b/app/src/main/res/layout/activity_news.xml
@@ -18,7 +18,6 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:itemBackground="@color/baby_blue"
         app:itemIconTint="@color/black"
         app:itemTextColor="@color/black"
@@ -27,15 +26,15 @@
         app:itemPaddingBottom="10dp"
         app:itemActiveIndicatorStyle="@android:color/transparent"
         android:theme="@style/Theme.SmishingDetectionApp"
-        app:menu="@menu/activity_main_drawer" />
+        app:menu="@menu/activity_main_drawer">
 
 
         <ImageView
-            android:id="@+id/HardhatLogo"
+            android:id="@+id/new_logo"
             android:layout_width="64dp"
             android:layout_height="64dp"
             android:layout_marginEnd="12dp"
-            app:srcCompat="@drawable/hardhat_logo"
+            app:srcCompat="@drawable/new_logo"
             android:contentDescription="@string/logo_description" />
 
         <TextView
@@ -50,23 +49,24 @@
     </LinearLayout>
 
     <!-- RecyclerView: occupies major space -->
+
+    <!-- Full-width Refresh button at bottom of content -->
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/news_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:scrollbars="vertical"
-        android:scrollbarSize="5dp"
-        android:scrollbarThumbVertical="@android:color/darker_gray"
+        android:contentDescription="@string/logo_description"
         android:paddingTop="4dp"
         android:paddingBottom="4dp"
-        app:layout_constraintTop_toBottomOf="@id/topHeaderContainer"
+        android:scrollbarSize="5dp"
+        android:scrollbarThumbVertical="@android:color/darker_gray"
+        android:scrollbars="vertical"
         app:layout_constraintBottom_toTopOf="@id/refreshButton"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/new_logo"
-        android:contentDescription="@string/logo_description" />
+        app:layout_constraintTop_toBottomOf="@id/topHeaderContainer"
+        app:layout_constraintVertical_bias="1.0"
+        app:srcCompat="@drawable/new_logo" />
 
-    <!-- Full-width Refresh button at bottom of content -->
     <Button
         android:id="@+id/refreshButton"
         android:layout_width="0dp"


### PR DESCRIPTION
This pull request addresses FE-018 by visually enhancing the layout of the News section in the app. Specifically:

Corrected the alignment of the header (topHeaderContainer) to ensure the "ACCC Scamwatch News" title appears fixed at the top of the screen.

Removed conflicting constraints that were causing the header to appear centered 

Verified that the RecyclerView now scrolls correctly beneath the header.